### PR TITLE
rtl8821cu: fix the link rate on some devices

### DIFF
--- a/package/ctcgfw/rtl8821cu/patches/050-change-value-of-vht-enable.patch
+++ b/package/ctcgfw/rtl8821cu/patches/050-change-value-of-vht-enable.patch
@@ -1,0 +1,11 @@
+--- a/os_dep/linux/os_intfs.c
++++ b/os_dep/linux/os_intfs.c
+@@ -238,7 +238,7 @@
+ #endif /* CONFIG_80211N_HT */
+ 
+ #ifdef CONFIG_80211AC_VHT
+-int rtw_vht_enable = 1; /* 0:disable, 1:enable, 2:force auto enable */
++int rtw_vht_enable = 2; /* 0:disable, 1:enable, 2:force auto enable */
+ module_param(rtw_vht_enable, int, 0644);
+ 
+ int rtw_ampdu_factor = 7;


### PR DESCRIPTION
From user feedback, we should change this option to avoid slow link
speed on some wireless network cards.
Ref: brektrou/rtl8821CU/issues #5